### PR TITLE
[minor] Updates dockerhub namespaces for docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ There are a few environmental variables used in this test. Here is an example:
 
 In order to test, a container with VPP 18.04 and vpp-app has been created:
 ```
-  docker pull bmcfall/vpp-centos-userspace-cni
+  docker pull bmcfall/vpp-centos-userspace-cni:0.2.0
 ```
 
 Setup your configuration file in your CNI directory. An example is
@@ -173,7 +173,7 @@ dumps interleaved.
 To verify the local config, in another window:
 ```
 vppctl show interface
-vppclt show mode
+vppctl show mode
 vppctl show memif
 ```
 
@@ -183,7 +183,7 @@ starts VPP and then runs *vpp-app*. Assuming the same notes above, to see what i
 cause *vpp-centos-userspace-cni* container to start in bash and skip the script, then run VPP and *vpp-app* manually: 
 ```
    cd $GOPATH/src/github.com/containernetworking/cni/scripts
-   sudo CNI_PATH=$CNI_PATH GOPATH=$GOPATH ./scripts/vpp-docker-run.sh -it --privileged vpp-centos-userspace-cni bash
+   sudo CNI_PATH=$CNI_PATH GOPATH=$GOPATH ./scripts/vpp-docker-run.sh -it --privileged bmcfall/vpp-centos-userspace-cni:0.2.0 bash
    
    /* Within Container: */
    vpp -c /etc/vpp/startup.conf &

--- a/scripts/vpp-docker-run.sh
+++ b/scripts/vpp-docker-run.sh
@@ -7,7 +7,7 @@
 scriptpath=$GOPATH/src/github.com/containernetworking/cni/scripts
 echo $scriptpath
 
-contid=$(docker run -d --net=none vpp-centos-userspace-cni /bin/sleep 10000000)
+contid=$(docker run -d --net=none bmcfall/vpp-centos-userspace-cni:0.2.0 /bin/sleep 10000000)
 pid=$(docker inspect -f '{{ .State.Pid }}' $contid)
 netnspath=/proc/$pid/ns/net
 


### PR DESCRIPTION
Billy, this should in theory work, but, there's a couple options here...

1. For the first README fix, you could just push a `:latest` tagged image, and it'd fix the readme. For the second readme fix, it needs the `bmcfall/` prefix, but, not the `:0.2.0` if you push a latest image.
2. For the script fix, that will need the `bmcfall/vpp-centos-userspace-cni`, but... it doesn't need the `:0.2.0`  tag if you push the `:latest` tagged image as per above.